### PR TITLE
feat!: Validate config before copy

### DIFF
--- a/molecule/converge.yml
+++ b/molecule/converge.yml
@@ -2,7 +2,7 @@
   become: true
   hosts: all
   vars:
-    nomad_version: "1.2.6"
+    nomad_version: "1.3.2"
 
     nomad_config:
       datacenter: "dev"

--- a/tasks/01-install.yml
+++ b/tasks/01-install.yml
@@ -63,7 +63,7 @@
     owner: "{{ nomad_user }}"
     group: "{{ nomad_group }}"
     mode: 0640
-    validate: "nomad config validate -config-format=json %s"
+    validate: "nomad config validate %s"
   notify: restart nomad
 
 - name: create nomad service file

--- a/tasks/01-install.yml
+++ b/tasks/01-install.yml
@@ -63,6 +63,7 @@
     owner: "{{ nomad_user }}"
     group: "{{ nomad_group }}"
     mode: 0640
+    validate: "nomad validate -config-format=json %s"
   notify: restart nomad
 
 - name: create nomad service file

--- a/tasks/01-install.yml
+++ b/tasks/01-install.yml
@@ -63,7 +63,7 @@
     owner: "{{ nomad_user }}"
     group: "{{ nomad_group }}"
     mode: 0640
-    validate: "nomad validate -config-format=json %s"
+    validate: "nomad config validate -config-format=json %s"
   notify: restart nomad
 
 - name: create nomad service file

--- a/tasks/02-configs.yml
+++ b/tasks/02-configs.yml
@@ -14,7 +14,7 @@
     owner: "{{ nomad_user }}"
     group: "{{ nomad_group }}"
     mode: 0640
-    validate: "nomad config validate -config-format=json {{ nomad_dirs.main.path }}/nomad.json %s"
+    validate: "nomad config validate {{ nomad_dirs.main.path }}/nomad.json %s"
   notify: restart nomad
   loop: "{{ nomad_configs | dict2items }}"
   loop_control:

--- a/tasks/02-configs.yml
+++ b/tasks/02-configs.yml
@@ -14,6 +14,7 @@
     owner: "{{ nomad_user }}"
     group: "{{ nomad_group }}"
     mode: 0640
+    validate: "nomad validate -config-format=json {{ nomad_dirs.main.path }}/nomad.json %s"
   notify: restart nomad
   loop: "{{ nomad_configs | dict2items }}"
   loop_control:

--- a/tasks/02-configs.yml
+++ b/tasks/02-configs.yml
@@ -14,7 +14,7 @@
     owner: "{{ nomad_user }}"
     group: "{{ nomad_group }}"
     mode: 0640
-    validate: "nomad validate -config-format=json {{ nomad_dirs.main.path }}/nomad.json %s"
+    validate: "nomad config validate -config-format=json {{ nomad_dirs.main.path }}/nomad.json %s"
   notify: restart nomad
   loop: "{{ nomad_configs | dict2items }}"
   loop_control:


### PR DESCRIPTION
Nomad support `config validate` since [v1.3.0](https://github.com/hashicorp/nomad/releases/tag/v1.3.0)